### PR TITLE
錯誤狀況mài cache siunn久。

### DIFF
--- a/fatchord-WaveRNN/nginx-cache/default.conf
+++ b/fatchord-WaveRNN/nginx-cache/default.conf
@@ -16,6 +16,7 @@ server {
     proxy_pass http://backend;
     add_header X-Cache-Status $upstream_cache_status;
     proxy_cache suisiann_cache;
-    proxy_cache_valid any 1y;
+    proxy_cache_valid 200 206 1y;
+    proxy_cache_valid any 30s;
   }
 }


### PR DESCRIPTION
## 需求

因為事故 [#1338](https://github.com/i3thuan5/TsuAn-BunKiann/issues/1338#issuecomment-2556213265) ，有人大量合成長句，造成服務無法度用ê時，cache 500狀態。


## 變更時間
2024.12.20

## 做法

- 200 kah 206 cache 1 冬，其他cache 30 秒就好。
- Kā 舊cache總hìnn-sak。


## 影響

對咱服務ê機密、完整、可用3方面ê影響分析：

### 機密

無。

### 完整

無。

### 可用

itaigi合成過ê詞ài重合成，資源會佔較tsē。


## 解決做法Github連結

這PR

## 未來規劃

另外參詳。

### 審查意見
